### PR TITLE
Fix Make Image

### DIFF
--- a/flowc/redhat-ubi7/base.Dockerfile
+++ b/flowc/redhat-ubi7/base.Dockerfile
@@ -10,7 +10,7 @@ RUN rpm --import /etc/yum.repos.d/centos7.gpg
 
 RUN yum -y install vim curl jq bc ssh unzip \
  git make autoconf automake pkgconfig libtool libtool-ltdl gdb \
- openssl-devel redhat-lsb-core libcurl-devel libxml2-devel libicu-devel uuid-devel \
+ openssl-devel libxml2-devel libicu-devel uuid-devel \
  gcc-c++ file graphviz devtoolset-7 \
  && yum clean all -y
 


### PR DESCRIPTION
## Description

Last version of Redhat-ubi7 has already installed `redhat-lsb-core` and `libcurl-devel` for different platforms, so try to install/update them using `yum` produce an errors during the `make image` process.

## Details

Remove no needed packages:
- redhat-lsb-core
- libcurl-devel